### PR TITLE
Fixes command handler behaviour when command is inconsistent with current state

### DIFF
--- a/commandhandler/src/main/scala/org/amitayh/invoices/commandhandler/CommandHandler.scala
+++ b/commandhandler/src/main/scala/org/amitayh/invoices/commandhandler/CommandHandler.scala
@@ -1,18 +1,6 @@
 package org.amitayh.invoices.commandhandler
 
-import java.lang.{Iterable => JIterable}
-import java.util.Collections.{emptyList, singletonList}
-
-import org.amitayh.invoices.common.Config
-import org.amitayh.invoices.common.domain.{CommandResult, Event, InvoiceSnapshot}
-import org.amitayh.invoices.common.serde.AvroSerde.{CommandResultSerde, CommandSerde, EventSerde, SnapshotSerde}
-import org.amitayh.invoices.common.serde.UuidSerde
 import org.amitayh.invoices.streamprocessor.{StreamProcessorApp, TopologyDefinition}
-import org.apache.kafka.streams.kstream.{Consumed, Produced, ValueMapper}
-import org.apache.kafka.streams.state.Stores
-import org.apache.kafka.streams.{StreamsBuilder, Topology}
-
-import scala.collection.JavaConverters._
 
 object CommandHandler extends StreamProcessorApp  {
 
@@ -23,17 +11,3 @@ object CommandHandler extends StreamProcessorApp  {
 
 
 
-object ToSuccessful extends ValueMapper[CommandResult, JIterable[CommandResult.Success]] {
-  override def apply(result: CommandResult): JIterable[CommandResult.Success] = result match {
-    case CommandResult(_, _, success: CommandResult.Success) => singletonList(success)
-    case _ => emptyList[CommandResult.Success]
-  }
-}
-
-object ToSnapshots extends ValueMapper[CommandResult.Success, InvoiceSnapshot] {
-  override def apply(result: CommandResult.Success): InvoiceSnapshot = result.newSnapshot
-}
-
-object ToEvents extends ValueMapper[CommandResult.Success, JIterable[Event]] {
-  override def apply(result: CommandResult.Success): JIterable[Event] = result.events.asJava
-}

--- a/commandhandler/src/main/scala/org/amitayh/invoices/commandhandler/CommandHandlerTopologyDefinition.scala
+++ b/commandhandler/src/main/scala/org/amitayh/invoices/commandhandler/CommandHandlerTopologyDefinition.scala
@@ -1,13 +1,18 @@
 package org.amitayh.invoices.commandhandler
 
+import java.lang.{Iterable => JIterable}
+import java.util.Collections.{emptyList, singletonList}
+
 import org.amitayh.invoices.common.Config
 import org.amitayh.invoices.common.domain.{CommandResult, Event, InvoiceSnapshot}
 import org.amitayh.invoices.common.serde.AvroSerde.{CommandResultSerde, CommandSerde, EventSerde, SnapshotSerde}
 import org.amitayh.invoices.common.serde.UuidSerde
 import org.amitayh.invoices.streamprocessor.TopologyDefinition
 import org.apache.kafka.streams.StreamsBuilder
-import org.apache.kafka.streams.kstream.{Consumed, Produced}
+import org.apache.kafka.streams.kstream.{Consumed, Produced, ValueMapper}
 import org.apache.kafka.streams.state.Stores
+
+import scala.collection.JavaConverters._
 
 // Extracted topology definition to allow testing
 object CommandHandlerTopologyDefinition extends TopologyDefinition {
@@ -45,4 +50,20 @@ object CommandHandlerTopologyDefinition extends TopologyDefinition {
 
     builder
   }
+}
+
+
+object ToSuccessful extends ValueMapper[CommandResult, JIterable[CommandResult.Success]] {
+  override def apply(result: CommandResult): JIterable[CommandResult.Success] = result match {
+    case CommandResult(_, _, success: CommandResult.Success) => singletonList(success)
+    case _ => emptyList[CommandResult.Success]
+  }
+}
+
+object ToSnapshots extends ValueMapper[CommandResult.Success, InvoiceSnapshot] {
+  override def apply(result: CommandResult.Success): InvoiceSnapshot = result.newSnapshot
+}
+
+object ToEvents extends ValueMapper[CommandResult.Success, JIterable[Event]] {
+  override def apply(result: CommandResult.Success): JIterable[Event] = result.events.asJava
 }

--- a/common/src/main/scala/org/amitayh/invoices/common/domain/Invoice.scala
+++ b/common/src/main/scala/org/amitayh/invoices/common/domain/Invoice.scala
@@ -50,7 +50,12 @@ case class Invoice(customer: Customer,
 }
 
 object Invoice {
-  val Draft = Invoice(
+
+  // Represents a non-existing invoice
+  // FIXME This is just a fix over the previous implementation, as the same state was used as an initial state when processing
+  //        a CreateInvoice command, but also to represent a non-existing Invoice for all other commands.
+  //        The snapshot should probably contain a Option[Invoice] rather than Invoice and no Invoice.None should exist
+  val None = Invoice(
     customer = Customer.Empty,
     issueDate = LocalDate.MIN,
     dueDate = LocalDate.MAX,

--- a/common/src/main/scala/org/amitayh/invoices/common/domain/InvoiceError.scala
+++ b/common/src/main/scala/org/amitayh/invoices/common/domain/InvoiceError.scala
@@ -11,3 +11,11 @@ case class VersionMismatch(actual: Int, expected: Option[Int]) extends InvoiceEr
 case class LineItemDoesNotExist(index: Int) extends InvoiceError {
   override def message: String = s"Line item #$index does not exist"
 }
+
+case class InvoiceDoesNotExist() extends InvoiceError {
+  override def message: String = "Trying to modify the state of a non-existing Invoice"
+}
+
+case class InvoiceAlreadyExists() extends InvoiceError {
+  override def message: String = "Trying to create an invoice that already exists"
+}

--- a/common/src/main/scala/org/amitayh/invoices/common/domain/InvoiceSnapshot.scala
+++ b/common/src/main/scala/org/amitayh/invoices/common/domain/InvoiceSnapshot.scala
@@ -16,3 +16,10 @@ case class InvoiceSnapshot(invoice: Invoice,
     else Left(VersionMismatch(version, expectedVersion))
 
 }
+
+object EmptyInvoiceSnapshot extends InvoiceSnapshot(InvoiceReducer.empty, 0, Instant.MIN) {
+  override def validateVersion(expectedVersion: Option[Int]): Either[InvoiceError, Invoice] =
+    expectedVersion
+        .fold[Either[InvoiceError, Invoice]](Right(Invoice.None))(_ => Left(VersionMismatch(0, expectedVersion)))
+
+}

--- a/common/src/main/scala/org/amitayh/invoices/common/domain/Reducer.scala
+++ b/common/src/main/scala/org/amitayh/invoices/common/domain/Reducer.scala
@@ -1,7 +1,5 @@
 package org.amitayh.invoices.common.domain
 
-import java.time.Instant
-
 trait Reducer[S, E] {
   def empty: S
   def handle(s: S, e: E): S
@@ -15,7 +13,8 @@ trait Reducer[S, E] {
 object InvoiceReducer extends Reducer[Invoice, Event.Payload] {
 
   // This implicitly defines the initial state of the Invoice
-  override val empty: Invoice = Invoice.Draft
+  // FIXME this is not quite right: it works for CreateInvoice, but makes other commands not to fail when the invoice does not exist
+  override val empty: Invoice = Invoice.None
 
   override def handle(invoice: Invoice, event: Event.Payload): Invoice = event match {
       // Here is the business logic defining the aggregate state changes when an event occurs.
@@ -51,8 +50,7 @@ object InvoiceReducer extends Reducer[Invoice, Event.Payload] {
   * (precisely, the Event version is the Snapshot version + 1)
   */
 object SnapshotReducer extends Reducer[InvoiceSnapshot, Event] {
-  override val empty: InvoiceSnapshot =
-    InvoiceSnapshot(InvoiceReducer.empty, 0, Instant.MIN)
+  override val empty: InvoiceSnapshot = EmptyInvoiceSnapshot
 
   override def handle(snapshot: InvoiceSnapshot, event: Event): InvoiceSnapshot = {
     if (versionsMatch(snapshot, event)) updateSnapshot(snapshot, event)


### PR DESCRIPTION
Fixes #15: command handler behaviour when sending commands to a non existing invoice
Also fixes #14: command handler behaviour when trying to re-create an existing invoice.
Topology behaviour tests are disabled due to #16